### PR TITLE
Add support for sandbox tag

### DIFF
--- a/README.org
+++ b/README.org
@@ -8,6 +8,7 @@ As of this writing, only the following attributes are supported:
 - height :: Vertical dimension
 - width :: Horizontal dimension
 - allowfullscreen :: Whether to allow the iframe's contents to use [[https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen][requestFullscreen()]]
+- sandbox :: Controls the restrictions applied to the content embedded in the iframe
 - style :: This is the only [[https://www.w3.org/html/wg/spec/elements.html#global-attributes][global attribute]] that is supported.  It is implemented via the base [[https://packagist.org/packages/nichework/tag-builder][tag builder class]].
 
 * Configuring the allowed hosts

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -31,6 +31,7 @@ class Handler extends Tag {
 	protected ?array $attrMap = [
 		'allowfullscreen' => 'handleBool',
 		'height' => 'handleInt',
+		'sandbox' => 'handleString',
 		'src' => 'handleUrl',
 		'width' => 'handleInt',
 	];

--- a/tests/parser/iframeTests.txt
+++ b/tests/parser/iframeTests.txt
@@ -150,3 +150,47 @@ iframe a bool “no”
 <p><iframe src="http://json.example.com"></iframe>
 </p>
 !! end
+
+!! test
+Test iframe with empty-value sandbox (implicit)
+!! config
+iFrameDomains=["example.com"]
+!! wikitext
+<iframe src='http://example.com/' sandbox></iframe>
+!! html
+<p><iframe sandbox="" src="http://example.com/"></iframe>
+</p>
+!! end
+
+!! test
+Test iframe with empty-value sandbox (explicit)
+!! config
+iFrameDomains=["example.com"]
+!! wikitext
+<iframe src='http://example.com/' sandbox=""></iframe>
+!! html
+<p><iframe sandbox="" src="http://example.com/"></iframe>
+</p>
+!! end
+
+!! test
+Test iframe with single-value sandbox
+!! config
+iFrameDomains=["example.com"]
+!! wikitext
+<iframe src='http://example.com/' sandbox="allow-scripts"></iframe>
+!! html
+<p><iframe sandbox="allow-scripts" src="http://example.com/"></iframe>
+</p>
+!! end
+
+!! test
+Test iframe with multi-value sandbox
+!! config
+iFrameDomains=["example.com"]
+!! wikitext
+<iframe src='http://example.com/' sandbox="allow-forms allow-scripts"></iframe>
+!! html
+<p><iframe sandbox="allow-forms allow-scripts" src="http://example.com/"></iframe>
+</p>
+!! end


### PR DESCRIPTION
Happy holidays!

I hope you'll consider merging this PR, which adds support for the `sandbox` attribute.

My use-case here is to improve the security of the iframes in my MediaWiki instance. I am relying on my users choosing to use this attribute when adding an iframe, as the `sandbox` attribute cannot be enforced in `LocalSettings.php` with this implementation.