### PR TITLE
Fix Title class in Config.php

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -7,7 +7,7 @@ use GlobalVarConfig;
 use JsonContent;
 use MediaWiki\MediaWikiServices;
 use stdClass;
-use Title;
+use MediaWiki\Title\Title;
 
 class Config extends GlobalVarConfig {
 


### PR DESCRIPTION
This small PR fixes the class used in the Config.php. It seems like something changed since MediaWiki 1.44 that now requires it to use MediaWiki/Title/Title instead of just Title, the same applies for MediaWiki/Html/Html (discovered this for another thing).